### PR TITLE
https://github.com/mbulat/plutus/pull/105

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,6 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'rspec-its'
   gem 'coveralls', require: false
+  gem 'jquery-rails'
+  gem 'jquery-ui-rails'
 end

--- a/app/assets/javascripts/plutus/application.js
+++ b/app/assets/javascripts/plutus/application.js
@@ -12,5 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require jquery-ui/datepicker
+//= require jquery-ui/widgets/datepicker
 //= require_tree .

--- a/app/models/plutus/entry.rb
+++ b/app/models/plutus/entry.rb
@@ -3,7 +3,7 @@ module Plutus
   # This table can be thought of as a traditional accounting Journal.
   #
   # Posting to a Ledger can be considered to happen automatically, since
-  # Accounts have the reverse 'has_many' relationship to either it's credit or
+  # Accounts have the reverse 'has_many' relationship to either its credit or
   # debit entries
   #
   # @example


### PR DESCRIPTION
Fix path in jQuery UI require in assets pipeline.

In recent versions of Rails, the right path is 'jquery-ui/widgets/<widget>'. See https://github.com/jquery-ui-rails/jquery-ui-rails#require-specific-modules for details.